### PR TITLE
Removed added whitespace from the TrackItSelfSignSSLCertificateOption…

### DIFF
--- a/functions/source/lambda-self-signed-certificate/index.js
+++ b/functions/source/lambda-self-signed-certificate/index.js
@@ -144,15 +144,18 @@ exports.handler = async (event, context) => {
                 throw new Error("'ExpiresOn' or 'Attributes.Days' must result in an expiration date at least one day in the future.");
             }
 
+            // Iterate over provided options list with 'short names' and substitute back 'long names' removing
+            // leading/trailing whitespace for the name and value
             var options = []
             for (var o of resourceProperties.Options.split(';')) {
                 o = o.split('=')
+                o[0] = o[0].trim()
                 if (_shortNames[o[0]] != null) {
                     o[0] = _shortNames[o[0]]
                 }
                 options.push({
                     'name': o[0].toCamelCase(),
-                    'value': o[1]
+                    'value': o[1].trim()
                 })
             }
             return await ssgenerate(options, attributes);

--- a/templates/bmc-trackit-main.template.yaml
+++ b/templates/bmc-trackit-main.template.yaml
@@ -387,10 +387,7 @@ Parameters:
   TrackItSelfSignSSLCertificateOptions:
     Type: String
     Description: (Optional) Self-signed certificate options. Not used if you configure a registered domain.
-    Default: CN=trackit.com;C=US;
-      L=Texas;ST=TX; 
-      O=trackit;OU=sales;
-      E=customer_support@bmc.com
+    Default: CN=trackit.com;C=US;L=Texas;ST=TX;O=trackit;OU=sales;E=customer_support@bmc.com
 
   TrackItSelfSignSSLCertificateExpiresOn:
     Type: String

--- a/templates/bmc-trackit-workload.template.yaml
+++ b/templates/bmc-trackit-workload.template.yaml
@@ -353,10 +353,7 @@ Parameters:
   TrackItSelfSignSSLCertificateOptions:
     Type: String
     Description: (Optional) Self-signed certificate options. Not used if you configure a registered domain.
-    Default: CN=trackit.com;C=US;
-      L=Texas;ST=TX; 
-      O=trackit;OU=sales;
-      E=customer_support@bmc.com
+    Default: CN=trackit.com;C=US;L=Texas;ST=TX;O=trackit;OU=sales;E=customer_support@bmc.com
 
   TrackItSelfSignSSLCertificateExpiresOn:
     Type: String


### PR DESCRIPTION
…s default values. Modified the self-sign lambda function to strip out leading/trailing whitespace in the 'options' string passed in

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
