### PR TITLE
Updated timeout value for Track-It! instance.

### DIFF
--- a/templates/bmc-trackit-workload.template.yaml
+++ b/templates/bmc-trackit-workload.template.yaml
@@ -895,7 +895,7 @@ Resources:
     Type: AWS::EC2::Instance
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT45M
+        Timeout: PT90M
     Metadata:
       cfn-lint:
         config:


### PR DESCRIPTION
*Description of changes:*
Updated timeout value for Track-It! instance to 90M.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.